### PR TITLE
Treat dashes in input file names as underscores

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 name: Build
 jobs:
   build:

--- a/source/compiler/compiler-file_descriptors.adb
+++ b/source/compiler/compiler-file_descriptors.adb
@@ -286,11 +286,16 @@ package body Compiler.File_Descriptors is
       return League.Strings.Universal_String
    is
       File_Name : constant String := Self.Name.Value.To_UTF_8_String;
-      Base_Name : constant String := Ada.Directories.Base_Name (File_Name);
+      Base_Name : constant League.Strings.Universal_String :=
+        League.Strings.From_UTF_8_String
+          (Ada.Directories.Base_Name (File_Name));
+      --  Replace every dash ('-') with underscore ('_') to make Base_Name
+      --  look like an identifier.
+      Fixed : constant League.Strings.Universal_String :=
+        Base_Name.Split ('-', League.Strings.Skip_Empty).Join ("_");
       PB_Pkg    : League.Strings.Universal_String;
       Result    : League.Strings.Universal_String :=
-        Compiler.Context.To_Ada_Name
-          (League.Strings.From_UTF_8_String (Base_Name));
+        Compiler.Context.To_Ada_Name (Fixed);
    begin
       if Self.PB_Package.Is_Set then
          PB_Pkg := Self.PB_Package.Value;


### PR DESCRIPTION
to map them on Ada identifiers and avoid compilation errors.
Fixes #4.