### PR TITLE
Fix type name clash from two imported files

### DIFF
--- a/source/compiler/compiler-context.adb
+++ b/source/compiler/compiler-context.adb
@@ -48,6 +48,23 @@ package body Compiler.Context is
       end if;
    end "+";
 
+
+   -------------------
+   -- Compound_Name --
+   -------------------
+
+   function Compound_Name
+     (Self            : Ada_Type_Name;
+      Current_Package : League.Strings.Universal_String)
+     return League.Strings.Universal_String
+   is
+      use type League.Strings.Universal_String;
+      Result : League.Strings.Universal_String := +Self;
+   begin
+      Result := Relative_Name (Result, Current_Package);
+      return Result.Split ('.', League.Strings.Skip_Empty).Join ("_");
+   end Compound_Name;
+
    --------------
    -- Get_File --
    --------------

--- a/source/compiler/compiler-context.ads
+++ b/source/compiler/compiler-context.ads
@@ -58,6 +58,12 @@ package Compiler.Context is
    function "+" (Self : Ada_Type_Name) return League.Strings.Universal_String;
    --  Join package name (if any) and type name into selected name.
 
+   function Compound_Name
+     (Self            : Ada_Type_Name;
+      Current_Package : League.Strings.Universal_String)
+     return League.Strings.Universal_String;
+   --  Join package name (if any) and type name using "_" for new identifiers.
+
    function Relative_Name
      (Full_Name       : League.Strings.Universal_String;
       Current_Package : League.Strings.Universal_String)

--- a/source/compiler/compiler-field_descriptors.adb
+++ b/source/compiler/compiler-field_descriptors.adb
@@ -75,7 +75,8 @@ package body Compiler.Field_Descriptors is
        return Boolean;
 
    function Read_Name
-     (Self : Google.Protobuf.Descriptor.Field_Descriptor_Proto)
+     (Self : Google.Protobuf.Descriptor.Field_Descriptor_Proto;
+      Pkg  : League.Strings.Universal_String)
       return League.Strings.Universal_String;
 
    function Write_Name
@@ -467,7 +468,7 @@ package body Compiler.Field_Descriptors is
         (Result,
          F.New_Statement
            (F.New_Apply
-             (Prefix    => F.New_Selected_Name (Read_Name (Self)),
+             (Prefix    => F.New_Selected_Name (Read_Name (Self, Pkg)),
               Arguments => F.New_List
                 ((F.New_Argument_Association (F.New_Name (+"Stream")),
                   F.New_Argument_Association
@@ -486,7 +487,8 @@ package body Compiler.Field_Descriptors is
    ---------------
 
    function Read_Name
-     (Self : Google.Protobuf.Descriptor.Field_Descriptor_Proto)
+     (Self : Google.Protobuf.Descriptor.Field_Descriptor_Proto;
+      Pkg  : League.Strings.Universal_String)
       return League.Strings.Universal_String
    is
       use all type Google.Protobuf.Descriptor.PB_Type;
@@ -498,8 +500,9 @@ package body Compiler.Field_Descriptors is
       if Self.Type_Name.Is_Set
         and then Compiler.Context.Named_Types.Contains (Self.Type_Name.Value)
       then
-         Result := Compiler.Context.Named_Types
-           (Self.Type_Name.Value).Ada_Type.Type_Name;
+         Result := Compiler.Context.Compound_Name
+           (Compiler.Context.Named_Types (Self.Type_Name.Value).Ada_Type,
+            Pkg);
          Result.Append ("_IO.Read");
       elsif Self.PB_Type.Is_Set and then Self.PB_Type.Value in
         TYPE_INT64 | TYPE_UINT64 | TYPE_INT32 | TYPE_UINT32
@@ -671,8 +674,9 @@ package body Compiler.Field_Descriptors is
          end if;
       elsif Is_Enum then
 
-         Get := Compiler.Context.Named_Types
-           (Self.Type_Name.Value).Ada_Type.Type_Name;
+         Get := Compiler.Context.Compound_Name
+           (Compiler.Context.Named_Types (Self.Type_Name.Value).Ada_Type,
+            Pkg);
 
          Result := F.New_List
            ((F.New_Argument_Association (F.New_Name (+"WS")),

--- a/source/compiler/compiler-file_descriptors.adb
+++ b/source/compiler/compiler-file_descriptors.adb
@@ -106,7 +106,8 @@ package body Compiler.File_Descriptors is
                     (Result,
                      F.New_Type
                        (Name          => F.New_Name
-                          ("Integer_" & Info.Ada_Type.Type_Name),
+                          ("Integer_" & Compiler.Context.Compound_Name
+                             (Info.Ada_Type, Pkg)),
                         Definition    => F.New_Infix
                           (+"range",
                            F.New_List
@@ -123,14 +124,16 @@ package body Compiler.File_Descriptors is
                     (Result,
                      F.New_Package_Instantiation
                        (Name        => F.New_Name
-                          (Info.Ada_Type.Type_Name & "_IO"),
+                          (Compiler.Context.Compound_Name
+                             (Info.Ada_Type, Pkg) & "_IO"),
                         Template    => F.New_Selected_Name
                           (+"PB_Support.IO.Enum_IO"),
                         Actual_Part => F.New_List
                           ((F.New_Argument_Association
                               (F.New_Selected_Name (Full)),
                             F.New_Name
-                              ("Integer_" & Info.Ada_Type.Type_Name),
+                              ("Integer_" &  Compiler.Context.Compound_Name
+                                 (Info.Ada_Type, Pkg)),
                             F.New_Argument_Association
                               (F.New_Selected_Name
                                 (Full & "_Vectors"))))));
@@ -143,7 +146,8 @@ package body Compiler.File_Descriptors is
                     (Result,
                      F.New_Package_Instantiation
                        (Name        => F.New_Name
-                          (Info.Ada_Type.Type_Name & "_IO"),
+                          (Compiler.Context.Compound_Name
+                             (Info.Ada_Type, Pkg) & "_IO"),
                         Template    => F.New_Selected_Name
                           (+"PB_Support.IO.Message_IO"),
                         Actual_Part => F.New_List


### PR DESCRIPTION
The fixed case is:
a.proto
b.proto
c.proto

package A in a.proto defines message T.
package B in b.proto defines message T.
c.proto imports both a.proto and b.proto and uses A.T and B.T.

The compiler generated a body from c.proto which had name clashes for
generic instantiation (*_IO packages) and type declarations (Integer_*).