### PR TITLE
Include build options for Protobuf_Runtime

### DIFF
--- a/gnat/protobuf_runtime.gpr
+++ b/gnat/protobuf_runtime.gpr
@@ -33,9 +33,78 @@ library project Protobuf_Runtime is
    for Library_ALI_Dir use "../.libs/adapbrt";
    for Library_Version use "libadapbrt.so." & Version;
 
+
+   for Languages use ("Ada");
+
+   for Create_Missing_Dirs use "True";
+
+   type Enabled_Kind is ("enabled", "disabled");
+   Compile_Checks : Enabled_Kind := External ("PROTOBUF_COMPILE_CHECKS", "enabled");
+   Runtime_Checks : Enabled_Kind := External ("PROTOBUF_RUNTIME_CHECKS", "enabled");
+   Style_Checks : Enabled_Kind := External ("PROTOBUF_STYLE_CHECKS", "enabled");
+   Contracts_Checks : Enabled_Kind := External ("PROTOBUF_CONTRACTS", "enabled");
+
+   type Build_Kind is ("debug", "optimize");
+   Build_Mode : Build_Kind := External ("PROTOBUF_BUILD_MODE", "optimize");
+
+   Compile_Checks_Switches := ();
+   case Compile_Checks is
+      when "enabled" =>
+         Compile_Checks_Switches :=
+           ("-gnatwa");  -- All warnings
+      when others => null;
+   end case;
+
+   Runtime_Checks_Switches := ();
+   case Runtime_Checks is
+      when "enabled" => null;
+      when others =>
+         Runtime_Checks_Switches :=
+           ("-gnatp"); -- Supress checks
+   end case;
+
+   Style_Checks_Switches := ();
+   case Style_Checks is
+      when "enabled" =>
+         Style_Checks_Switches :=
+           ("-gnatyg",   -- GNAT Style checks
+            "-gnatyd",   -- No DOS line terminators
+            "-gnatyM80", -- Maximum line length
+            "-gnatyO");  -- Overriding subprograms explicitly marked as such
+      when others => null;
+   end case;
+
+   Contracts_Switches := ();
+   case Contracts_Checks is
+      when "enabled" =>
+         Contracts_Switches :=
+           ("-gnata"); --  Enable assertions and contracts
+      when others => null;
+   end case;
+
+   Build_Switches := ();
+   case Build_Mode is
+      when "optimize" =>
+         Build_Switches := ("-O3",     -- Optimization
+                            "-gnatn"); -- Enable inlining
+      when "debug" =>
+         Build_Switches := ("-g",       -- Debug info
+                            "-Og",      -- No optimization
+                            "-gnatVa"); -- All validity checks
+   end case;
+
    package Compiler is
-      for Default_Switches ("ada") use
-        ("-gnat12", "-gnatW8", "-g", "-gnatVa", "-gnatwa", "-gnaty", "-gnata");
+      for Default_Switches ("Ada") use
+        Compile_Checks_Switches &
+        Build_Switches &
+        Runtime_Checks_Switches &
+        Contracts_Switches &
+        ("-gnatQ",  -- Don't quit. Generate ALI and tree files even if illegalities
+         "-gnat12", "-gnatW8");
    end Compiler;
+
+   package Binder is
+      for Switches ("Ada") use ("-Es"); --  Symbolic traceback
+   end Binder;
 
 end Protobuf_Runtime;


### PR DESCRIPTION
Include options for Compile_Checks, Runtime_Checks, Style_Checks and Contracts_Checks (enabled or disabled).

Include option for Build_Mode (optimize or debug).

Based on what Alire generates as initial GPR file and flags already present (`-gnat12` and `-gnatW8`).