### PR TITLE
Fix action by upgrading actions/cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           repository: protocolbuffers/protobuf
           path: google
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: google_cache
           key: ${{ runner.os }}-google-fc33


### PR DESCRIPTION
The execution fails with a deprecation notice for v1.

See https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down