### PR TITLE
Don't preppend extra dot (`.`) if there is no package

### DIFF
--- a/source/compiler/compiler-file_descriptors.adb
+++ b/source/compiler/compiler-file_descriptors.adb
@@ -287,9 +287,10 @@ package body Compiler.File_Descriptors is
      (Self : Google.Protobuf.Descriptor.File_Descriptor_Proto)
        return League.Strings.Universal_String
    is
-      Result : League.Strings.Universal_String := +".";
+      Result : League.Strings.Universal_String;
    begin
       if Self.PB_Package.Is_Set then
+         Result.Append (".");
          Result.Append (Self.PB_Package.Value);
       end if;
 

--- a/testsuite/no_pkg/not_used.ads
+++ b/testsuite/no_pkg/not_used.ads
@@ -1,0 +1,3 @@
+--  This dummy package in not used in the test.
+--  I need it just to keep `cp -v *.ad[sb] ...` working
+package Not_Used is end;

--- a/testsuite/no_pkg/test.proto
+++ b/testsuite/no_pkg/test.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+message AnimalSpecies {
+   message SpeciesDescription {
+     string a_name = 1;
+     string a_family = 2;
+   }
+ }
+ message Animal {
+   AnimalSpecies.SpeciesDescription a_details = 1;
+   string a_name = 2;
+ }


### PR DESCRIPTION
because in this case intername type names has only single dot: `.Animal`, not `..Animal`.

Fix #42