### PR TITLE
Restore task-safety in `PB_Support.Internal`

### DIFF
--- a/source/runtime/pb_support-internal.adb
+++ b/source/runtime/pb_support-internal.adb
@@ -357,15 +357,15 @@ package body PB_Support.Internal is
      (Self  : in out Stream;
       Value : League.Strings.Universal_String) is
    begin
-      if Codec.Is_Empty then
-         Codec.Replace_Element
+      if Self.Codec.Is_Empty then
+         Self.Codec.Replace_Element
            (League.Text_Codecs.Codec
               (League.Strings.To_Universal_String ("utf-8")));
       end if;
 
       declare
          Data : constant League.Stream_Element_Vectors.Stream_Element_Vector :=
-           Codec.Constant_Reference.Encode (Value);
+           Self.Codec.Constant_Reference.Encode (Value);
       begin
          Self.Write (Data);
       end;

--- a/source/runtime/pb_support-internal.ads
+++ b/source/runtime/pb_support-internal.ads
@@ -447,6 +447,9 @@ private
 
    type Message_Id is new Positive;
 
+   package Text_Codec_Holders is new Ada.Containers.Indefinite_Holders
+     (League.Text_Codecs.Text_Codec, League.Text_Codecs."=");
+
    package Size_Vectors is new Ada.Containers.Vectors
      (Index_Type   => Message_Id,
       Element_Type => Ada.Streams.Stream_Element_Count,
@@ -468,6 +471,8 @@ private
       --  calculate total size of messages
       Written  : Ada.Streams.Stream_Element_Count := 0;
       --  Total amount of written data during riffling mode
+      Codec    : Text_Codec_Holders.Holder;
+      --  Text codec for encoding strings in this stream.
    end record;
 
    overriding procedure Read
@@ -478,10 +483,5 @@ private
    overriding procedure Write
      (Stream : in out Internal.Stream;
       Item   : Ada.Streams.Stream_Element_Array);
-
-   package Text_Codec_Holders is new Ada.Containers.Indefinite_Holders
-     (League.Text_Codecs.Text_Codec, League.Text_Codecs."=");
-
-   Codec : Text_Codec_Holders.Holder;
 
 end PB_Support.Internal;


### PR DESCRIPTION
After pull request #20, commit
78cc26e6f19889d9323c13a28865dcd2da01de9f
we introduced a point where the runtime is not reentrant. By including a Text_Codec particular of each stream we can assure that multiple tasks can enter to initialize and use the package with its own codec, restoring task safety.